### PR TITLE
Fix redirect issue in password_expired_controller

### DIFF
--- a/app/controllers/devise/password_expired_controller.rb
+++ b/app/controllers/devise/password_expired_controller.rb
@@ -11,7 +11,7 @@ class Devise::PasswordExpiredController < DeviseController
   end
 
   def update
-    redirect_to :root if not resource.nil? and resource.need_change_password?
+    return redirect_to :root if resource.nil?
 
     resource.extend(Devise::Models::DatabaseAuthenticatablePatch)
     if resource.update_with_password(resource_params)

--- a/test/controllers/test_password_expired_controller.rb
+++ b/test/controllers/test_password_expired_controller.rb
@@ -1,0 +1,89 @@
+require 'test_helper'
+
+class TestPasswordExpiredController < ActionController::TestCase
+  include Devise::TestHelpers
+
+  def setup
+    @controller = Devise::PasswordExpiredController.new
+    @request.env['devise.mapping'] = Devise.mappings[:user]
+    @user = User.create!(
+      username: 'foo',
+      password: 'password1',
+      password_confirmation: 'password1'
+    )
+  end
+
+  test 'redirects to root when resource is not present' do
+    patch :update
+    assert_redirected_to :root
+    assert_nil flash[:notice]
+  end
+
+  test 'updates password and redirects to root when resource is present' do
+    sign_in @user
+    patch :update,
+          user: {
+            current_password: 'password1',
+            password: 'newpassword',
+            password_confirmation: 'newpassword'
+          }
+    assert_redirected_to :root
+    assert_equal 'Your new password is saved.', flash[:notice]
+    refute_equal @user.encrypted_password, @user.reload.encrypted_password
+  end
+
+  test 'renders show when password does not match password_confirmation' do
+    sign_in @user
+    patch :update,
+          user: {
+            current_password: 'password1',
+            password: 'newpassword',
+            password_confirmation: ''
+          }
+    assert_template :show
+  end
+
+  test 'renders show when new password is same as old password' do
+    sign_in @user
+    patch :update,
+          user: {
+            current_password: 'password1',
+            password: 'password1',
+            password_confirmation: 'password1'
+          }
+    assert_template :show
+  end
+
+  test 'renders show when current password is wrong' do
+    sign_in @user
+    patch :update,
+          user: {
+            current_password: 'invalidpassword',
+            password: 'password1',
+            password_confirmation: 'password1'
+          }
+    assert_template :show
+  end
+
+  test 'renders show when current password is blank' do
+    sign_in @user
+    patch :update,
+          user: {
+            current_password: '',
+            password: 'password1',
+            password_confirmation: 'password1'
+          }
+    assert_template :show
+  end
+
+  test 'renders show when only current password is filled in' do
+    sign_in @user
+    patch :update,
+          user: {
+            current_password: 'password1',
+            password: '',
+            password_confirmation: ''
+          }
+    assert_template :show
+  end
+end

--- a/test/dummy/app/controllers/application_controller.rb
+++ b/test/dummy/app/controllers/application_controller.rb
@@ -1,0 +1,3 @@
+class ApplicationController < ActionController::Base
+  protect_from_forgery
+end

--- a/test/dummy/app/controllers/home_controller.rb
+++ b/test/dummy/app/controllers/home_controller.rb
@@ -1,0 +1,4 @@
+class HomeController < ApplicationController
+  def index
+  end
+end

--- a/test/dummy/app/models/user.rb
+++ b/test/dummy/app/models/user.rb
@@ -1,3 +1,4 @@
 class User < ActiveRecord::Base
-  devise :database_authenticatable, :password_archivable, :paranoid_verification
+  devise :database_authenticatable, :password_archivable, :paranoid_verification,
+         :password_expirable
 end

--- a/test/dummy/config/initializers/secret_key_base.rb
+++ b/test/dummy/config/initializers/secret_key_base.rb
@@ -1,0 +1,7 @@
+# Be sure to restart your server when you modify this file.
+
+# Your secret key for verifying the integrity of signed cookies.
+# If you change this key, all old signed cookies will become invalid!
+# Make sure the secret is at least 30 characters and all random,
+# no regular words or you'll be exposed to dictionary attacks.
+RailsApp::Application.config.secret_key_base = '6ce0185270c02b9e0057e538cfa7fd42b7e4266f14a31165c27667e18d92979f2c01a748b667bacfa5d6540e8ed26201452d1cab274f5ed7e7a4cfec23849d6d'

--- a/test/dummy/config/routes.rb
+++ b/test/dummy/config/routes.rb
@@ -1,0 +1,8 @@
+RailsApp::Application.routes.draw do
+  devise_for :users
+
+  match '/users/password_expired' => 'devise/password_expired#update', via: [:put, :patch]
+  get '/users/password_expired' => 'devise/password_expired#show'
+
+  root to: 'home#index'
+end

--- a/test/dummy/db/migrate/20120508165529_create_tables.rb
+++ b/test/dummy/db/migrate/20120508165529_create_tables.rb
@@ -8,8 +8,12 @@ class CreateTables < ActiveRecord::Migration
       t.string :email,              null: false, default: ''
       t.string :encrypted_password, null: false, default: ''
 
+      ## :password_expirable
+      t.datetime :password_changed_at
+
       t.timestamps
     end
+    add_index :users, :password_changed_at
 
     create_table :old_passwords do |t|
       t.string :encrypted_password


### PR DESCRIPTION
The code was doing the opposite of what it was intended to do.
It was redirecting to root when the resource is present and when the
resource needs a password change.

Also, this caused `redirect` to be called multiple times in the same
action because calling `redirect_to :root` will not terminate
execution of the action. It will continue to execute the rest of the
code even if the original condition returns true. To stop execution,
you have to add `and return` or use a guard clause, as I did here.

I also added tests for the update action, and configured the dummy
Rails app to support the tests.
